### PR TITLE
Update chromepolicy.go to follow the updated Chrome CT policy.

### DIFF
--- a/ctpolicy/ctpolicy.go
+++ b/ctpolicy/ctpolicy.go
@@ -33,6 +33,7 @@ type LogGroupInfo struct {
 	Name          string
 	LogURLs       map[string]bool    // set of members
 	MinInclusions int                // Required number of submissions.
+	MinOperators  int                // Required number of distinct CT log operators.
 	IsBase        bool               // True only for Log-group covering all logs.
 	LogWeights    map[string]float32 // weights used for submission, default weight is 1
 	wMu           sync.RWMutex       // guards weights
@@ -203,6 +204,15 @@ func lifetimeInMonths(cert *x509.Certificate) int {
 		lifetimeInMonths--
 	}
 	return lifetimeInMonths
+}
+
+// lifetimeInDays calculates and returns cert lifetime expressed in days
+// flooring incomplete days.
+func lifetimeInDays(cert *x509.Certificate) int {
+	start := cert.NotBefore
+	end := cert.NotAfter
+	days := end.Sub(start).Hours() / 24
+	return int(days)
 }
 
 // GroupSet is set of Log-group names.

--- a/ctpolicy/ctpolicy_test.go
+++ b/ctpolicy/ctpolicy_test.go
@@ -27,7 +27,7 @@ import (
 
 func getTestCertPEMShort() *x509.Certificate {
 	cert, _ := x509util.CertificateFromPEM([]byte(testdata.TestCertPEM))
-	cert.NotAfter = time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC)
+	cert.NotAfter = time.Date(2012, 6, 1, 0, 0, 0, 0, time.UTC)
 	return cert
 }
 
@@ -99,6 +99,52 @@ func TestLifetimeInMonths(t *testing.T) {
 			got := lifetimeInMonths(cert)
 			if got != test.want {
 				t.Errorf("lifetimeInMonths(%v, %v)=%d, want %d", test.notBefore, test.notAfter, got, test.want)
+			}
+		})
+	}
+}
+
+func TestLifetimeInDays(t *testing.T) {
+	tests := []struct {
+		name      string
+		notBefore time.Time
+		notAfter  time.Time
+		want      int
+	}{
+		{
+			name:      "ExactDays",
+			notBefore: time.Date(2012, 6, 1, 0, 0, 0, 0, time.UTC),
+			notAfter:  time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC),
+			want:      214,
+		},
+		{
+			name:      "ExactYears",
+			notBefore: time.Date(2012, 6, 1, 0, 0, 0, 0, time.UTC),
+			notAfter:  time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC),
+			want:      944,
+		},
+		{
+			name:      "PartialSingleDay",
+			notBefore: time.Date(2012, 6, 1, 0, 0, 0, 0, time.UTC),
+			notAfter:  time.Date(2012, 6, 1, 15, 0, 0, 0, time.UTC),
+			want:      0,
+		},
+		{
+			name:      "PartialDays",
+			notBefore: time.Date(2012, 6, 25, 0, 0, 0, 0, time.UTC),
+			notAfter:  time.Date(2012, 6, 30, 12, 0, 0, 0, time.UTC),
+			want:      5,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cert := getTestCertPEMLongOriginal()
+			cert.NotBefore = test.notBefore
+			cert.NotAfter = test.notAfter
+			got := lifetimeInDays(cert)
+			if got != test.want {
+				t.Errorf("lifetimeInDays(%v, %v)=%d, want %d", test.notBefore, test.notAfter, got, test.want)
 			}
 		})
 	}

--- a/submission/races.go
+++ b/submission/races.go
@@ -55,7 +55,9 @@ type safeSubmissionState struct {
 	mu          sync.Mutex
 	logToGroups map[string]ctpolicy.GroupSet
 	groupNeeds  map[string]int
+	minGroups   int
 
+	groups  map[string]bool
 	results map[string]*submissionResult
 	cancels map[string]context.CancelFunc
 }
@@ -67,6 +69,10 @@ func newSafeSubmissionState(groups ctpolicy.LogPolicyData) *safeSubmissionState 
 	for _, g := range groups {
 		s.groupNeeds[g.Name] = g.MinInclusions
 	}
+	if baseGroup, ok := groups[ctpolicy.BaseName]; ok {
+		s.minGroups = baseGroup.MinOperators
+	}
+	s.groups = make(map[string]bool)
 	s.results = make(map[string]*submissionResult)
 	s.cancels = make(map[string]context.CancelFunc)
 	return &s
@@ -116,6 +122,7 @@ func (sub *safeSubmissionState) setResult(logURL string, sct *ct.SignedCertifica
 		if sub.groupNeeds[groupName] > 0 {
 			sub.results[logURL] = &submissionResult{sct: sct, err: err}
 		}
+		sub.groups[groupName] = true
 		sub.groupNeeds[groupName]--
 	}
 
@@ -164,6 +171,9 @@ func (sub *safeSubmissionState) groupComplete(groupName string) bool {
 	needs, ok := sub.groupNeeds[groupName]
 	if !ok {
 		return true
+	}
+	if len(sub.groups) < sub.minGroups {
+		return false
 	}
 	return needs <= 0
 }

--- a/submission/races_test.go
+++ b/submission/races_test.go
@@ -139,11 +139,34 @@ func TestGetSCTs(t *testing.T) {
 					Name:          ctpolicy.BaseName,
 					LogURLs:       map[string]bool{"a1.com": true, "a2.com": true, "a3.com": true, "a4.com": true, "b1.com": true, "b2.com": true, "b3.com": true, "b4.com": true},
 					MinInclusions: 5,
+					MinOperators:  2,
 					IsBase:        true,
 					LogWeights:    map[string]float32{"a1.com": 1.0, "a2.com": 1.0, "a3.com": 1.0, "a4.com": 1.0, "b1.com": 1.0, "b2.com": 1.0, "b3.com": 1.0, "b4.com": 1.0},
 				},
 			},
 			resultTrail: map[string]int{"a": 1, "b": 1, ctpolicy.BaseName: 5},
+		},
+		{
+			name:   "notEnoughDistinctOperators",
+			sbMock: &mockSubmitter{fixedDelay: map[byte]time.Duration{'a': 0, 'b': 2 * time.Second}, firstLetterURLReqNumber: make(map[byte]int)},
+			groups: ctpolicy.LogPolicyData{
+				"a": {
+					Name:          "a",
+					LogURLs:       map[string]bool{"a1.com": true, "a2.com": true, "a3.com": true, "a4.com": true},
+					MinInclusions: 1,
+					IsBase:        false,
+					LogWeights:    map[string]float32{"a1.com": 1.0, "a2.com": 1.0, "a3.com": 1.0, "a4.com": 1.0},
+				},
+				ctpolicy.BaseName: {
+					Name:          ctpolicy.BaseName,
+					LogURLs:       map[string]bool{"a1.com": true, "a2.com": true, "a3.com": true, "a4.com": true},
+					MinInclusions: 2,
+					MinOperators:  2,
+					IsBase:        true,
+					LogWeights:    map[string]float32{"a1.com": 1.0, "a2.com": 1.0, "a3.com": 1.0, "a4.com": 1.0},
+				},
+			},
+			errRegexp: regexp.MustCompile("didn't receive enough SCTs"),
 		},
 	}
 


### PR DESCRIPTION
Add extra fields to the safeSubmissionState struct that can keep track of how many distinct CT operators return an SCT and the minimum number of distinct CT log operators needed to return an SCT.

<!---
Describe your changes in detail here.
If this fixes an issue, please write "Fixes #123", substituting the issue number.
-->

### Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
Feel free to not tick any boxes that don't apply to this PR (e.g. refactoring may not need a CHANGELOG update).
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the [CHANGELOG](CHANGELOG.md).
  - Adjust the draft version number according to [semantic versioning](https://semver.org/) rules.
- [ ] I have updated [documentation](docs/) accordingly.
